### PR TITLE
Remove dependency on < rails 5

### DIFF
--- a/include_media_rails.gemspec
+++ b/include_media_rails.gemspec
@@ -30,11 +30,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "railties", ">= 3.1", "< 5"
+  spec.add_dependency "railties", ">= 3.1"
   spec.add_dependency "sass",  ">= 3.3", "< 4" # Include Media needs sass maps
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "rails", ">= 3.1", "< 5"
+  spec.add_development_dependency "rails", ">= 3.1"
 end


### PR DESCRIPTION
This opens up gem for use with rails 5.0.0

Addresses #6 
